### PR TITLE
Add docker file and workflow to publish docker images

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -1,0 +1,64 @@
+name: Create and publish a Docker image
+
+# Based on example from https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
+
+# Configures this workflow to run every time a change is pushed to the main branch
+on:
+  push:
+    branches: ['main']
+
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Based on https://github.com/j-rivero/ionic_testing/blob/main/Dockerfile
+FROM ros:rolling
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y dirmngr curl git python3 python3-docopt python3-yaml python3-distro sudo mesa-utils \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone https://github.com/gazebo-tooling/gzdev \
+    && cd gzdev \
+    && python3 gzdev.py repository enable osrf stable \
+    && python3 gzdev.py repository enable osrf prerelease \
+    && python3 gzdev.py repository enable osrf nightly
+RUN apt-get install -y gz-ionic \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Also install libdart dependencies to avoid building dart vendor packages from source
+RUN apt-get update \
+    && apt-get install -y libdart6.13-collision-bullet-dev libdart6.13-collision-ode-dev libdart6.13-dev libdart6.13-external-ikfast-dev libdart6.13-external-odelcpsolver-dev libdart6.13-utils-urdf-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /root/ws/src
+WORKDIR /root/ws
+COPY ionic_demo.repos .
+RUN vcs import --input ionic_demo.repos src
+RUN rosdep update
+RUN apt-get update \
+    && rosdep install --from-paths src --ignore-src -r --rosdistro rolling -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN . /opt/ros/rolling/setup.sh \
+      && MAKEFLAGS=-j6 GZ_RELAX_VERSION_MATCH=1 colcon build --symlink-install --packages-up-to ionic_demo
+COPY entrypoint.sh /ionic_entrypoint.sh
+ENTRYPOINT ["/ionic_entrypoint.sh"]
+CMD ["bash"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+source ~/ws/install/setup.bash
+exec "$@"

--- a/ionic_demo.repos
+++ b/ionic_demo.repos
@@ -1,0 +1,101 @@
+repositories:
+  gz_vendor/gz_dartsim_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_dartsim_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_cmake_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_cmake_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_common_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_common_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_fuel_tools_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_gui_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_gui_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_launch_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_launch_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_math_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_math_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_msgs_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_msgs_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_physics_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_physics_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_plugin_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_plugin_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_rendering_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_rendering_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_sensors_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_sensors_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_sim_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_sim_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_tools_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_tools_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_transport_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_transport_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/gz_utils_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_utils_vendor.git
+    version: rolling
+  gz_vendor/gz_libs/sdformat_vendor:
+    type: git
+    url: https://github.com/gazebo-release/sdformat_vendor.git
+    version: rolling
+  gz_vendor/gz_ogre_next_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_ogre_next_vendor.git
+    version: rolling
+  gz_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gz_ros2_control
+    version: rolling
+  ionic_demo:
+    type: git
+    url: https://github.com/gazebosim/ionic_demo.git
+    version: main
+  navigation2:
+    type: git
+    url: https://github.com/ros-navigation/navigation2
+    version: main
+  nav2_minimal_turtlebot_simulation:
+    type: git
+    url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation
+    version: main
+  panda_ign_moveit2:
+    type: git
+    url: https://github.com/azeey/panda_ign_moveit2/
+    version: ionic_demo
+  ros_gz:
+    type: git
+    url: https://github.com/gazebosim/ros_gz
+    version: ros2
+  sdformat_urdf:
+    type: git
+    url: https://github.com/ros/sdformat_urdf
+    version: rolling


### PR DESCRIPTION
* Since we don't have Ionic gz_vendor packages released into Rolling,  packages that need Gazebo need to be built from source. This includes `ros_gz`, `gz_ros2_control`, and `sdformat_urdf` (we don't currently need this, but might in follow-up PRs).
* Nav2 binaries are not available on Rolling, so it needs to be built from source as well.
* This will hopefully publish docker images to the GitHub docker registry.
