### PR TITLE
Update GUI camera near far plane

### DIFF
--- a/ionic_demo/worlds/ionic.sdf
+++ b/ionic_demo/worlds/ionic.sdf
@@ -18,8 +18,8 @@
         <scene>scene</scene>
         <sky></sky>
         <camera_clip>
-          <near>0.25</near>
-          <far>50000</far>
+          <near>0.01</near>
+          <far>500</far>
         </camera_clip>
         <camera_pose>-5.4 -1.15 1.75 0.0 0.11 0.73</camera_pose>
       </plugin>


### PR DESCRIPTION
So that we can zoom in to models without getting cropped by the near clip plane.

Current behavior - large near clip plane crops the scene in infront of the camera

![ionic_demo_camera_near_clip](https://github.com/user-attachments/assets/1b4a98e4-e2d9-4432-be8e-a440b02b98c1)
