### PR TITLE
Remove unnecessary environment variable setting

### DIFF
--- a/ionic_demo/launch/ionic_moveit_demo_launch.py
+++ b/ionic_demo/launch/ionic_moveit_demo_launch.py
@@ -12,30 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
-
-from ament_index_python.packages import get_package_share_directory, get_package_prefix
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare, FindPackagePrefix
 from launch_xml.launch_description_sources import XMLLaunchDescriptionSource
 
 from launch import LaunchDescription
-from launch.actions import AppendEnvironmentVariable, IncludeLaunchDescription
+from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, TextSubstitution
 
 
 def generate_launch_description():
-    rmf_demo_assets_dir = Path(get_package_share_directory('rmf_demos_assets')) / 'models'
-    rmf_plugins_dir = Path(get_package_prefix('rmf_robot_sim_gz_plugins')) / 'lib' / 'rmf_robot_sim_gz_plugins'
-
-    set_resource_path_vars = AppendEnvironmentVariable(
-        'GZ_SIM_RESOURCE_PATH', str(rmf_demo_assets_dir)
-    )
-    set_plugin_path_vars = AppendEnvironmentVariable(
-        'GZ_SIM_SYSTEM_PLUGIN_PATH', str(rmf_plugins_dir)
-    )
-
     coke_can_string = \
     '''
     <sdf version="1.6">
@@ -49,8 +36,6 @@ def generate_launch_description():
     '''
 
     return LaunchDescription([
-        set_resource_path_vars,
-        set_plugin_path_vars,
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource([
                 PathJoinSubstitution([


### PR DESCRIPTION
Since https://github.com/open-rmf/rmf_demos/pull/262 and https://github.com/open-rmf/rmf_simulation/pull/136 were merged, environment hooks will be used for the necessary variables and as such we can remove them from the moveit launch file, making it a fair bit simpler (and most importantly not depending on RMF packages).